### PR TITLE
Implement AutoWineLabel and update wine displays

### DIFF
--- a/app/components/AutoWineLabel.tsx
+++ b/app/components/AutoWineLabel.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+interface AutoWineLabelProps {
+  name: string;
+  vintage?: string | number;
+  region?: string;
+  color: string;
+}
+
+const colorSchemes: Record<string, { primary: string; secondary: string; text: string }> = {
+  red: { primary: '#8B0000', secondary: '#F5F2E9', text: '#1A1A1A' },
+  white: { primary: '#D4AF37', secondary: '#FFFFFF', text: '#1A1A1A' },
+  rose: { primary: '#C48A81', secondary: '#FFF5F5', text: '#1A1A1A' },
+  sparkling: { primary: '#FFD700', secondary: '#FFFFFF', text: '#1A1A1A' },
+  fortified: { primary: '#5E2129', secondary: '#F5F5F5', text: '#FFFFFF' },
+};
+
+export default function AutoWineLabel({ name, vintage, region, color }: AutoWineLabelProps) {
+  const scheme = colorSchemes[color] || colorSchemes.red;
+
+  return (
+    <svg width="200" height="250" xmlns="http://www.w3.org/2000/svg">
+      <rect
+        width="100%"
+        height="100%"
+        rx="12"
+        fill={scheme.secondary}
+        stroke={scheme.primary}
+        strokeWidth="4"
+      />
+      <text
+        x="50%"
+        y="80"
+        textAnchor="middle"
+        fontSize="18"
+        fontFamily="serif"
+        fontWeight="bold"
+        fill={scheme.primary}
+      >
+        {name}
+      </text>
+      {vintage && (
+        <text
+          x="50%"
+          y="120"
+          textAnchor="middle"
+          fontSize="14"
+          fontFamily="serif"
+          fill={scheme.text}
+        >
+          {vintage}
+        </text>
+      )}
+      {region && (
+        <text
+          x="50%"
+          y="150"
+          textAnchor="middle"
+          fontSize="12"
+          fontFamily="sans-serif"
+          fill={scheme.text}
+        >
+          {region}
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -29,7 +29,6 @@ import AddIcon from '@mui/icons-material/Add';
 import LiquorIcon from '@mui/icons-material/Liquor';
 import SportsBarIcon from '@mui/icons-material/SportsBar';
 import WarehouseIcon from '@mui/icons-material/Warehouse';
-import LabelIcon from '@mui/icons-material/Label';
 
 export default function Navbar() {
   const router = useRouter();
@@ -100,7 +99,6 @@ export default function Navbar() {
     },
     { label: 'ACCORDS METS-VINS', icon: <RestaurantIcon />, path: '/food-pairing' },
     { label: 'DÉGUSTATIONS', icon: <LocalBarIcon />, path: '/tasting-notes' },
-    { label: 'ÉTIQUETTES', icon: <LabelIcon />, path: '/generate-label' },
     {
       label: 'ANALYSES & SUGGESTIONS',
       icon: <PieChartIcon />,

--- a/app/components/WineCard.tsx
+++ b/app/components/WineCard.tsx
@@ -2,7 +2,7 @@
 // app/components/WineCard.tsx
 import React from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
+import AutoWineLabel from './AutoWineLabel';
 import { Chip } from '@mui/material';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import PlaceIcon from '@mui/icons-material/Place';
@@ -16,19 +16,17 @@ type WineCardProps = {
   region?: string | null;
   appellation?: string | null;
   price?: number | null;
-  imageUrl?: string | null;
 };
 
 export default function WineCard({ 
-  id, 
-  name, 
-  color, 
-  vintage, 
-  domain, 
-  region, 
-  appellation, 
-  price, 
-  imageUrl 
+  id,
+  name,
+  color,
+  vintage,
+  domain,
+  region,
+  appellation,
+  price
 }: WineCardProps) {
   
   // Fonction pour obtenir les styles de couleur de vin
@@ -50,14 +48,13 @@ export default function WineCard({
     <Link href={`/wines/${id}`} className="block group">
       <div className="wine-card h-full flex flex-col">
         <div className="relative">
-          {/* Image container avec taille fixe */}
+          {/* Affichage de l'étiquette automatique */}
           <div className="aspect-[2/3] w-full bg-gray-100 overflow-hidden flex items-center justify-center">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={imageUrl || 'https://placehold.co/300x450/EAEAEA/333333?text=Vin'}
-              alt={name}
-              className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-500"
-              loading="lazy"
+            <AutoWineLabel
+              name={name}
+              vintage={vintage ?? undefined}
+              region={region ?? undefined}
+              color={color}
             />
           </div>
           

--- a/app/wines/[id]/page.tsx
+++ b/app/wines/[id]/page.tsx
@@ -18,7 +18,6 @@ import Navbar from '../../components/Navbar';
 import { supabase } from '../../utils/supabase';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
-import Image from 'next/image';
 import WineAgingCurve from '../../components/WineAgingCurve';
 import TastingRadarChart from '../../components/TastingRadarChart';
 import AppellationInfo from '../../components/AppellationInfo';
@@ -569,21 +568,9 @@ export default function WineDetail() {
             {/* Visualisation de la bouteille */}
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 flex flex-col items-center">
               <div className="h-64 flex items-center justify-center">
-                {wine.image_url ? (
-                  <div className="h-full w-full relative">
-                    <Image 
-                      src={wine.image_url} 
-                      alt={wine.name} 
-                      fill
-                      style={{ objectFit: 'contain' }}
-                      sizes="(max-width: 768px) 100vw, 300px"
-                    />
-                  </div>
-                ) : (
-                  <div className="h-full w-32 flex items-center justify-center">
-                    {renderWineBottle(wine)}
-                  </div>
-                )}
+                <div className="h-full w-32 flex items-center justify-center">
+                  {renderWineBottle(wine)}
+                </div>
               </div>
             </div>
 

--- a/app/wines/page.tsx
+++ b/app/wines/page.tsx
@@ -462,7 +462,6 @@ export default function Wines() {
                   region={wine.region}
                   appellation={wine.appellation}
                   price={wine.price}
-                  imageUrl={wine.image_url}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- add `AutoWineLabel` component for reusable SVG labels
- update `WineCard` to render the SVG label
- simplify wine detail bottle display
- remove "ÉTIQUETTES" nav link
- use new label component in wine list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684be2f5d528832b89923c46675d9729