### PR TITLE
Fix auto placement effect initialization order

### DIFF
--- a/app/storage/page.tsx
+++ b/app/storage/page.tsx
@@ -169,11 +169,6 @@ export default function StorageManagement() {
     setInventoryGroups(grouped);
   }, [inventoryMode, bottles, unassignedBottles]);
 
-  useEffect(() => {
-    if (!inventoryMode) return;
-    handleAutoPlacement();
-  }, [handleAutoPlacement, inventoryMode]);
-
   // Récupérer les clés API
   const fetchAPIKeys = useCallback(async () => {
     try {
@@ -275,7 +270,13 @@ export default function StorageManagement() {
       showNotification(`Erreur: ${error instanceof Error ? error.message : 'Placement impossible'}`, 'error');
     }
   }, [emptyPositions, fetchPositionsAndBottles, filters, selectedLocation, showNotification, unassignedBottles]);
-  
+
+  useEffect(() => {
+    if (!inventoryMode) return;
+
+    handleAutoPlacement();
+  }, [handleAutoPlacement, inventoryMode]);
+
   // Marquer une bouteille comme consommée
   const handleConsumeBottle = async () => {
     if (!selectedBottle) return;


### PR DESCRIPTION
## Summary
- relocate the auto-placement effect to run after the handler is defined
- preserve inventory grouping and auto-placement behavior while preventing initialization errors

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dbb774e883209426f2bfc8864ab3)