### PR TITLE
Add fallback wine search when RPC unavailable

### DIFF
--- a/app/storage/page.tsx
+++ b/app/storage/page.tsx
@@ -202,6 +202,52 @@ export default function StorageManagement() {
     fetchAPIKeys();
   }, [fetchLocations, fetchAPIKeys]);
 
+  // Optimisation du placement des bouteilles
+  const handleOptimizePlacement = useCallback(async () => {
+    if (!selectedLocation || bottles.length === 0) {
+      showNotification('Aucune bouteille à optimiser', 'info');
+      return;
+    }
+
+    const sortedPositions = [...positions].sort((a, b) =>
+      a.row_position === b.row_position
+        ? a.column_position - b.column_position
+        : a.row_position - b.row_position
+    );
+
+    const sortedBottles = [...bottles].sort((a, b) => {
+      const dateA = a.acquisition_date ? new Date(a.acquisition_date).getTime() : 0;
+      const dateB = b.acquisition_date ? new Date(b.acquisition_date).getTime() : 0;
+      return dateA - dateB;
+    });
+
+    const updates = sortedBottles
+      .map((bottle, index) => ({ id: bottle.id, position_id: sortedPositions[index]?.id || null }))
+      .filter(update => {
+        const currentBottle = bottles.find(b => b.id === update.id);
+        return currentBottle?.position_id !== update.position_id;
+      });
+
+    if (updates.length === 0) {
+      showNotification('Les bouteilles sont déjà positionnées de manière compacte', 'info');
+      return;
+    }
+
+    try {
+      const { error } = await supabase
+        .from('bottle')
+        .upsert(updates, { onConflict: 'id' });
+
+      if (error) throw error;
+
+      showNotification('Optimisation effectuée', 'success');
+      fetchPositionsAndBottles(selectedLocation.id, filters);
+    } catch (error: unknown) {
+      console.error('Erreur optimisation placement:', error);
+      showNotification(`Erreur: ${error instanceof Error ? error.message : 'Optimisation impossible'}`, 'error');
+    }
+  }, [bottles, fetchPositionsAndBottles, filters, positions, selectedLocation, showNotification]);
+
   useEffect(() => {
     if (!autoOptimizeEnabled || !selectedLocation || bottles.length === 0) return;
 
@@ -221,7 +267,7 @@ export default function StorageManagement() {
   // Gérer le clic sur une position
   const handlePositionClick = (position: Position) => {
     const bottle = bottles.find(b => b.position_id === position.id);
-    
+
     if (bottle) {
       setSelectedBottle(bottle);
       setDialogOpen(true);
@@ -231,7 +277,7 @@ export default function StorageManagement() {
       handleOpenQuickAddDialog();
     }
   };
-  
+
   // Ouvrir le dialogue d'ajout de bouteille
   const handleOpenQuickAddDialog = (position?: Position) => {
     if (!selectedLocation) {
@@ -365,52 +411,6 @@ export default function StorageManagement() {
       fetchPositionsAndBottles(location.id, filters);
     }
   };
-
-  // Optimisation du placement des bouteilles
-  const handleOptimizePlacement = useCallback(async () => {
-    if (!selectedLocation || bottles.length === 0) {
-      showNotification('Aucune bouteille à optimiser', 'info');
-      return;
-    }
-
-    const sortedPositions = [...positions].sort((a, b) =>
-      a.row_position === b.row_position
-        ? a.column_position - b.column_position
-        : a.row_position - b.row_position
-    );
-
-    const sortedBottles = [...bottles].sort((a, b) => {
-      const dateA = a.acquisition_date ? new Date(a.acquisition_date).getTime() : 0;
-      const dateB = b.acquisition_date ? new Date(b.acquisition_date).getTime() : 0;
-      return dateA - dateB;
-    });
-
-    const updates = sortedBottles
-      .map((bottle, index) => ({ id: bottle.id, position_id: sortedPositions[index]?.id || null }))
-      .filter(update => {
-        const currentBottle = bottles.find(b => b.id === update.id);
-        return currentBottle?.position_id !== update.position_id;
-      });
-
-    if (updates.length === 0) {
-      showNotification('Les bouteilles sont déjà positionnées de manière compacte', 'info');
-      return;
-    }
-
-    try {
-      const { error } = await supabase
-        .from('bottle')
-        .upsert(updates, { onConflict: 'id' });
-
-      if (error) throw error;
-
-      showNotification('Optimisation effectuée', 'success');
-      fetchPositionsAndBottles(selectedLocation.id, filters);
-    } catch (error: unknown) {
-      console.error('Erreur optimisation placement:', error);
-      showNotification(`Erreur: ${error instanceof Error ? error.message : 'Optimisation impossible'}`, 'error');
-    }
-  }, [bottles, fetchPositionsAndBottles, filters, positions, selectedLocation, showNotification]);
 
   // Gestion de la recherche
   const handleSearch = () => {

--- a/app/wines/page.tsx
+++ b/app/wines/page.tsx
@@ -103,6 +103,40 @@ export default function Wines() {
     setNotification(prev => ({ ...prev, open: false }));
   }, []);
 
+  const fetchWineFallback = useCallback(async (term: string | null) => {
+    let query = supabase
+      .from('wine')
+      .select('*');
+
+    if (term) {
+      query = query.ilike('name', `%${term}%`);
+    }
+
+    if (filters.color) {
+      query = query.eq('color', filters.color);
+    }
+
+    if (filters.region) {
+      query = query.ilike('region', `%${filters.region}%`);
+    }
+
+    if (filters.priceRange) {
+      if (filters.priceRange === 'budget') query = query.lte('price', 15);
+      else if (filters.priceRange === 'medium') query = query.gte('price', 15).lte('price', 50);
+      else if (filters.priceRange === 'premium') query = query.gte('price', 50);
+    }
+
+    if (sortBy === 'name') query = query.order('name');
+    else if (sortBy === 'vintage') query = query.order('vintage', { ascending: false });
+    else if (sortBy === 'price') query = query.order('price', { ascending: false });
+
+    if (weightAvailability) {
+      query = query.order('availability_score', { ascending: false, nullsFirst: false });
+    }
+
+    return query;
+  }, [filters.color, filters.priceRange, filters.region, sortBy, weightAvailability]);
+
   // Fonction de récupération des vins
   const fetchWines = useCallback(async (options?: { semantic?: boolean; overrideSearch?: string }) => {
     setLoading(true);
@@ -137,6 +171,21 @@ export default function Wines() {
         ? await supabase.rpc('semantic_search_wines', { ...rpcParams, limit: 100 })
         : await supabase.rpc('search_wines', rpcParams);
 
+      if (error?.code === 'PGRST202') {
+        const { data: fallbackData, error: fallbackError } = await fetchWineFallback(term || null);
+        if (fallbackError) throw fallbackError;
+
+        setSemanticMode(false);
+        setWines((fallbackData as Wine[]) || []);
+        const regions = (fallbackData || [])
+          .filter((wine: Wine) => wine.region)
+          .map((wine: Wine) => wine.region as string)
+          .filter((region: string, index: number, self: string[]) => self.indexOf(region) === index)
+          .sort();
+        setUniqueRegions(regions);
+        return;
+      }
+
       if (error) {
         throw error;
       }
@@ -159,7 +208,7 @@ export default function Wines() {
       setLoading(false);
       setSemanticLoading(false);
     }
-  }, [filters.color, filters.priceRange, filters.region, router, searchTerm, showNotification, sortBy, weightAvailability]);
+  }, [fetchWineFallback, filters.color, filters.priceRange, filters.region, router, searchTerm, showNotification, sortBy, weightAvailability]);
 
   // Effet pour charger les vins au montage du composant
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add a Supabase table-query fallback when the `search_wines` RPC is unavailable
- preserve filtering/sorting and disable semantic mode when using the fallback

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dd2df34483208a34ef7c8a32dc18)